### PR TITLE
Version Check

### DIFF
--- a/.github/workflows/tests-conda.yml
+++ b/.github/workflows/tests-conda.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: [3.6, 3.9]
         os: [ubuntu-latest, windows-latest]
     name: "Test: Python ${{ matrix.python-version }}, conda, ${{ matrix.os }}"
     steps:

--- a/.github/workflows/tests-pip.yml
+++ b/.github/workflows/tests-pip.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.5]
-        os: ubuntu-latest
+        os: [ubuntu-latest]
     name: "Version Check: Python ${{ matrix.python-version }}"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests-pip.yml
+++ b/.github/workflows/tests-pip.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: [3.6, 3.9]
         os: [ubuntu-latest, windows-latest]
     name: "Test: Python ${{ matrix.python-version }}, pip, ${{ matrix.os }}"
     steps:
@@ -29,3 +29,24 @@ jobs:
     - name: Test with pytest
       run: |
         pytest tests
+
+  version-check:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5]
+        os: ubuntu-latest
+    name: "Version Check: Python ${{ matrix.python-version }}"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install cookiecutter~=1.7.2
+    - name: Test with pytest
+      run: |
+        python tests/version_check.py --fail

--- a/.github/workflows/tests-pip.yml
+++ b/.github/workflows/tests-pip.yml
@@ -33,6 +33,7 @@ jobs:
   version-check:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: [2.7, 3.5]
         os: [ubuntu-latest]
@@ -43,10 +44,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install Cookiecutter
       run: |
         python -m pip install --upgrade pip
         pip install cookiecutter~=1.7.2
-    - name: Test with pytest
+    - name: Run Version Check
       run: |
         python tests/version_check.py --fail

--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,11 @@ channels:
   - defaults
 dependencies:
   # no python version specified here, we use different versions in the CI pipeline
-  - pytest=5.*
+  - pytest>=5.4
+  - pytest-mock>=3.3.0
   - cookiecutter~=1.7.2
   - pyhocon=0.3.*
-  - PyYAML=5.*
+  - PyYAML>=5.3
   - pip
   - pip:
-    - typer~=0.2.1
+    - typer~=0.3.2

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,3 +1,9 @@
+"""
+This file contains the Post-Generate Hooks for Cookiecutter.
+They are executed AFTER the project has been generated, so you can adjust the final
+contents of the project folder, based on the user configuration. More details:
+https://cookiecutter.readthedocs.io/en/1.7.2/advanced/hooks.html
+"""
 import os
 import shutil
 import sys

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,6 +1,23 @@
+import platform
 import re
 import sys
+from distutils.version import StrictVersion
 
+import cookiecutter
+
+# check Python version (3.6 or higher)
+if sys.version_info < (3, 6):
+    print("ERROR: You are using Python {}, but Python 3.6 or higher is required "
+          "to use this template".format(platform.python_version()))
+    sys.exit(1)
+
+# check cookiecutter version (1.7.2 or higher)
+if StrictVersion(cookiecutter.__version__) < StrictVersion('1.7.2'):
+    print("ERROR: You are using cookiecutter {}, but cookiecutter 1.7.2 or higher is required "
+          "to use this template".format(cookiecutter.__version__))
+    sys.exit(1)
+
+# check the slug and module name
 SLUG_REGEX = r'^[a-zA-Z][-a-zA-Z0-9]+$'
 MODULE_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
 

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,3 +1,13 @@
+"""
+This file contains the Pre-Generate Hooks for Cookiecutter.
+They are executed AFTER the user entered their project config,
+but BEFORE the project is actually generated. More details:
+https://cookiecutter.readthedocs.io/en/1.7.2/advanced/hooks.html
+
+In this script we execute environment checks and run input validation.
+Because the environment check needs to work with old Python versions (e.g. Python 2.7),
+we need to avoid modern syntax features in this file, like f-strings and type hints.
+"""
 import platform
 import re
 import sys
@@ -6,7 +16,7 @@ from distutils.version import StrictVersion
 import cookiecutter
 
 # check Python version (3.6 or higher)
-if sys.version_info < (3, 6):
+if StrictVersion(platform.python_version()) < StrictVersion("3.6.0"):
     print("ERROR: You are using Python {}, but Python 3.6 or higher is required "
           "to use this template".format(platform.python_version()))
     sys.exit(1)
@@ -25,12 +35,13 @@ project_slug = '{{ cookiecutter.project_slug }}'
 module_name = '{{ cookiecutter.module_name }}'
 
 if not re.match(SLUG_REGEX, project_slug):
-    print(f"ERROR: {project_slug} is not a valid slug! It may only consist of numbers and letters "
-          f"of the english alphabet, begin with a letter, and must use dashes instead of whitespace.")
+    print("ERROR: {} is not a valid slug! It may only consist of numbers and letters of the "
+          "english alphabet, begin with a letter, and must use dashes instead of whitespace."
+          .format(project_slug))
     sys.exit(1)
 
 if not re.match(MODULE_REGEX, module_name):
-    print(f"ERROR: {module_name} is not a valid Python module name! "
-          f"See https://www.python.org/dev/peps/pep-0008/#package-and-module-names "
-          f"for naming standards.")
+    print("ERROR: {} is not a valid Python module name! "
+          "See https://www.python.org/dev/peps/pep-0008/#package-and-module-names "
+          "for naming standards.".format(module_name))
     sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 cookiecutter~=1.7.2
-pre-commit~=2.4.0
+pre-commit>=2.4.0
 
 # test dependencies
-pytest~=5.4.0
+pytest>=5.4.0
+pytest-mock>=3.3.0
 pyhocon~=0.3.54
-PyYAML~=5.3.1
-typer~=0.2.1
+PyYAML>=5.3.1
+typer~=0.3.2

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,5 +1,9 @@
+from runpy import run_path
+from typing import Any, Callable, Tuple
+
 import pytest
 from cookiecutter.exceptions import CookiecutterException
+from pytest_mock import MockerFixture
 
 from .util import check_project
 
@@ -17,3 +21,40 @@ def test_project_slug():
 def test_editor():
     check_project(settings={'editor_settings': "hax0r-editor-2000"})
     # note: invalid choices will be silently ignored by cookiecutter
+
+
+def test_fail_python_3_5(mocker: MockerFixture):
+    fail_python_version(mocker, (3, 5, 0))
+
+
+def test_fail_python_2_7(mocker: MockerFixture):
+    fail_python_version(mocker, (2, 7, 0))
+
+
+def test_fail_cookiecutter_1_6_0(mocker: MockerFixture):
+    fail_cookiecutter_version(mocker, "1.6.0")
+
+
+def test_fail_cookiecutter_1_7_1(mocker: MockerFixture):
+    fail_cookiecutter_version(mocker, "1.7.1")
+
+
+def fail_python_version(mocker: MockerFixture, version_info: Tuple[int, int, int]):
+    patch_cookiecutter_run_script(
+        mocker, lambda mocker: mocker.patch('sys.version_info', version_info))
+    with pytest.raises(SystemExit):
+        check_project()
+
+
+def fail_cookiecutter_version(mocker: MockerFixture, version_info: str):
+    patch_cookiecutter_run_script(
+        mocker, lambda mocker: mocker.patch('cookiecutter.__version__', version_info))
+    with pytest.raises(SystemExit):
+        check_project()
+
+
+def patch_cookiecutter_run_script(mocker: MockerFixture, patch_fun: Callable[[MockerFixture], Any]):
+    def run_script_wrapper(script_path, *args, **kwargs):
+        patch_fun(mocker)
+        run_path(script_path)
+    mocker.patch('cookiecutter.hooks.run_script', run_script_wrapper)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,5 +1,5 @@
 from runpy import run_path
-from typing import Any, Callable, Tuple
+from typing import Any, Callable
 
 import pytest
 from cookiecutter.exceptions import CookiecutterException
@@ -24,11 +24,11 @@ def test_editor():
 
 
 def test_fail_python_3_5(mocker: MockerFixture):
-    fail_python_version(mocker, (3, 5, 0))
+    fail_python_version(mocker, "3.5.0")
 
 
 def test_fail_python_2_7(mocker: MockerFixture):
-    fail_python_version(mocker, (2, 7, 0))
+    fail_python_version(mocker, "2.7.0")
 
 
 def test_fail_cookiecutter_1_6_0(mocker: MockerFixture):
@@ -39,9 +39,9 @@ def test_fail_cookiecutter_1_7_1(mocker: MockerFixture):
     fail_cookiecutter_version(mocker, "1.7.1")
 
 
-def fail_python_version(mocker: MockerFixture, version_info: Tuple[int, int, int]):
+def fail_python_version(mocker: MockerFixture, version_info: str):
     patch_cookiecutter_run_script(
-        mocker, lambda mocker: mocker.patch('sys.version_info', version_info))
+        mocker, lambda mocker: mocker.patch('platform.python_version', lambda: version_info))
     with pytest.raises(SystemExit):
         check_project()
 

--- a/tests/version_check.py
+++ b/tests/version_check.py
@@ -1,0 +1,31 @@
+import os
+import platform
+import shutil
+import sys
+import tempfile
+
+from cookiecutter.exceptions import FailedHookException
+from cookiecutter.main import cookiecutter
+
+expect_fail = '--fail' in sys.argv
+actual_fail = False
+
+root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+temp_dir = tempfile.mkdtemp()
+try:
+    cookiecutter(root, no_input=True, output_dir=temp_dir)
+except FailedHookException as e:
+    actual_fail = True
+finally:
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+if actual_fail == expect_fail:
+    print("Python {} {} as expected".format(
+        platform.python_version(),
+        "failed" if expect_fail else "succeeded"))
+else:
+    print("Python {} should have {}, but actually {}".format(
+        platform.python_version(),
+        "failed" if expect_fail else "succeeded",
+        "failed" if actual_fail else "succeeded"))
+    sys.exit(1)

--- a/tests/version_check.py
+++ b/tests/version_check.py
@@ -1,31 +1,40 @@
 import os
 import platform
 import shutil
+import subprocess
 import sys
 import tempfile
-
-from cookiecutter.exceptions import FailedHookException
-from cookiecutter.main import cookiecutter
 
 expect_fail = '--fail' in sys.argv
 actual_fail = False
 
+# run cookiecutter in a subprocess (so we can catch terminal output)
 root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 temp_dir = tempfile.mkdtemp()
 try:
-    cookiecutter(root, no_input=True, output_dir=temp_dir)
-except FailedHookException as e:
-    actual_fail = True
+    p = subprocess.Popen(
+        [sys.executable, '-m', 'cookiecutter', '--no-input', '-o', temp_dir, '.'],
+        cwd=root, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+    actual_fail = p.returncode != 0
 finally:
     shutil.rmtree(temp_dir, ignore_errors=True)
 
-if actual_fail == expect_fail:
-    print("Python {} {} as expected".format(
-        platform.python_version(),
-        "failed" if expect_fail else "succeeded"))
+# handle possible issues & give proper return codes
+if b'Python 3.6 or higher' in stdout or b'successfully created' in stdout:
+    if actual_fail == expect_fail:
+        print("Python {} {} as expected".format(
+            platform.python_version(),
+            "failed" if expect_fail else "succeeded"))
+    else:
+        print("Python {} should have {}, but actually {}".format(
+            platform.python_version(),
+            "failed" if expect_fail else "succeeded",
+            "failed" if actual_fail else "succeeded"))
+        sys.exit(1)
+elif b'SyntaxError' in stderr:
+    print("got a syntax error in pre_gen_project.py:\n" + str(stderr))
+    sys.exit(1)
 else:
-    print("Python {} should have {}, but actually {}".format(
-        platform.python_version(),
-        "failed" if expect_fail else "succeeded",
-        "failed" if actual_fail else "succeeded"))
+    print("unexpected error: " + str(stderr))
     sys.exit(1)


### PR DESCRIPTION
add a version check (for Python and cookiecutter) to the pre-gen hooks.

This way, we can notify the user that their Python version is outdated or that they should upgrade their cookiecutter installation, instead of throwing random error messages at them, e.g. slugify not available (cookiecutter 1.6 or lower) or f-strings are not supported (Python 3.5 or lower)