### PR TITLE
Whitespace in README.md

### DIFF
--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -19,12 +19,14 @@ def test_conda():
         settings={'package_manager': 'conda'},
         files_existent=['environment.yml', 'environment-dev.yml', 'setup.py'])
 
+
 def test_poetry():
     check_project(
         settings={'package_manager': 'poetry'},
         files_existent=['pyproject.toml'],
         files_non_existent=['environment.yml, environment-dev.yml', 'requirements.txt', 'requirements-dev.txt', 'setup.py']
     )
+
 
 def test_notebooks_yes():
     check_project(
@@ -55,6 +57,7 @@ def test_docker_poetry():
         settings={'use_docker': 'yes', 'package_manager': 'poetry',},
         files_existent=['Dockerfile', 'docker-compose.yml', '.dockerignore']
     )
+
 
 def test_docker_no():
     check_project(
@@ -118,6 +121,7 @@ def test_formatter_black_conda():
     check_project(
         settings={'code_formatter': 'black', 'package_manager': 'conda'},
         fun=check_black)
+
 
 def test_formatter_black_poetry():
     def check_black(project_dir: Path):

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -1,10 +1,15 @@
+{#- ------------------------------------------ -#}
+{#- Definition of Template Variables -#}
+{%- set py_command = 'poetry run python' if cookiecutter.package_manager == 'poetry' else 'python' -%}
+{%- set test_command = 'poetry run pytest tests' if cookiecutter.package_manager == 'poetry' else 'python setup.py test' -%}
+{%- set test_cov_command = 'poetry run pytest tests --cov=src --cov-report=xml' if cookiecutter.package_manager == 'poetry' else 'python setup.py testcov' -%}
+{%- set build_command = 'poetry build' if cookiecutter.package_manager == 'poetry' else 'python setup.py dist' -%}
+{%- set install_command = 'poetry add' if cookiecutter.package_manager == 'poetry' else 'conda install' if cookiecutter.package_manager == 'conda' else 'pip install' -%}
+{#- ------------------------------------------ -#}
 # {{ cookiecutter.project_name }}
+
 {{ cookiecutter.project_short_description }}
-{% set py_command = 'poetry run python' if cookiecutter.package_manager == 'poetry' else 'python' -%}
-{% set test_command = 'poetry run pytest tests' if cookiecutter.package_manager == 'poetry' else 'python setup.py test' -%}
-{% set test_cov_command = 'poetry run pytest tests --cov=src --cov-report=xml' if cookiecutter.package_manager == 'poetry' else 'python setup.py testcov' -%}
-{% set build_command = 'poetry build' if cookiecutter.package_manager == 'poetry' else 'python setup.py dist' %}
-{% set install_command = 'poetry add' if cookiecutter.package_manager == 'poetry' else 'conda install' if cookiecutter.package_manager == 'conda' else 'pip install' %}
+
 ## Getting Started
 {% if cookiecutter.package_manager == 'conda' %}
 To set up your local development environment, please use a fresh virtual environment.
@@ -77,7 +82,6 @@ To use your module code (`src/`) in Jupyter notebooks (`notebooks/`) without run
 
 This way, you'll always use the latest version of your module code in your notebooks via `import {{ cookiecutter.module_name }}`.
 {% endif %}
-
 Assuming you already have Jupyter installed, you can make your virtual environment available as a separate kernel by running:
 
     {{ install_command }} ipykernel


### PR DESCRIPTION
fix a couple of whitespace issues in the README.md and one of the test files.

I would love to use a linting tool for Markdown files as part of our tests (like [markdownlint](https://github.com/DavidAnson/markdownlint) for node.js), but there is no such tool available for Python and it would make our test setup much more complicated if we'd use node.js in addition to Python...