### PR TITLE
Add logging example code for when create_cli==no

### DIFF
--- a/{{cookiecutter.project_slug}}/notebooks/example.ipynb
+++ b/{{cookiecutter.project_slug}}/notebooks/example.ipynb
@@ -10,7 +10,28 @@
     "To use your module `{{ cookiecutter.module_name  }}` from here, run `pip install -e .` from the root of your project directory."
     {% endif %}
    ]
-  },
+  },{% if cookiecutter.config_file != 'none' %}
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    {% if cookiecutter.config_file == 'yaml' %}"import os\n",
+    {% endif %}"import logging\n",
+    "from {{ cookiecutter.module_name }} import util\n",
+	"\n",
+    "logger = logging.getLogger(\"{{ cookiecutter.module_name }}\")\n",
+    "\n",
+    "config = util.load_config({% if cookiecutter.config_file == 'yaml' %}os.path.join(os.path.abspath(os.pardir),\n",
+    "                                       \"config\",\n",
+    "                                       \"config.yml\"){% endif %})\n",
+    "util.logging_setup(config)\n",
+    "\n",
+	"logger.info(\"Use this setup to start logging in notebooks or to \"+\n",
+    "            \"get the correct logging format in your {{ cookiecutter.module_name }} module\")"
+   ]
+  },{% endif %}
   {
    "cell_type": "code",
    "execution_count": null,

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/main.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/main.py
@@ -1,6 +1,20 @@
+{% if cookiecutter.config_file != 'none' %}{% if cookiecutter.config_file == 'yaml' %}import os
+{% endif %}import logging
+from {{ cookiecutter.module_name }} import util
 
+logger = logging.getLogger("{{ cookiecutter.module_name }}")
+
+{% endif %}
 def main():
-    # TODO your journey starts here
+    {% if cookiecutter.config_file != 'none' %}config = util.load_config({% if cookiecutter.config_file == 'yaml' %}os.path.join(os.path.abspath(__file__),
+                                           *[os.pardir]*3,
+                                           "config",
+                                           "config.yml"){% endif %})
+    util.logging_setup(config)
+
+    logger.info("Looks like you're all set up. Let's get going!")
+
+    {% endif %}# TODO your journey starts here
     print("hello :)")
 
 


### PR DESCRIPTION
Extended files: 

    {{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/main.py
    {{cookiecutter.project_slug}}/notebooks/example.ipynb

Affected option: `config_file`

Chosing `hocon` option creates the following code in `main.py`:
```
import logging
from test_hocon import util

logger = logging.getLogger("test_hocon")


def main():
    config = util.load_config()
    util.logging_setup(config)

    logger.info("Looks like you're all set up. Let's get going!")

    # TODO your journey starts here
    print("hello :)")


if __name__ == "__main__":
    main()
```

and adds this cell content to `example.ipynb`:
```
import logging
from test_hocon import util

logger = logging.getLogger("test_hocon")

config = util.load_config()
util.logging_setup(config)

logger.info("Use this setup to start logging in notebooks or to "+
            "get the correct logging format in your test_hocon module")
```

Chosing `yaml` option creates the following code in `main.py`:
```
import os
import logging
from test_yaml import util

logger = logging.getLogger("test_yaml")


def main():
    config = util.load_config(os.path.join(os.path.abspath(__file__),
                                           *[os.pardir]*3,
                                           "config",
                                           "config.yml"))
    util.logging_setup(config)

    logger.info("Looks like you're all set up. Let's get going!")

    # TODO your journey starts here
    print("hello :)")


if __name__ == "__main__":
    main()
```

and adds this cell content to `example.ipynb`:
```
import os
import logging
from test_yaml import util

logger = logging.getLogger("test_yaml")

config = util.load_config(os.path.join(os.path.abspath(os.pardir),
                                       "config",
                                       "config.yml"))
util.logging_setup(config)

logger.info("Use this setup to start logging in notebooks or to "+
            "get the correct logging format in your test_yaml module")
```

The path construction to the `config.yml` may not be ideal, but could be fixed when addressing issue #38 .