### PR TITLE
Change python version to 3.9.* in "environment.yml"

### DIFF
--- a/{{cookiecutter.project_slug}}/environment-dev.yml
+++ b/{{cookiecutter.project_slug}}/environment-dev.yml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7.*
+  - python=3.9.*
   - pytest=5.*
   - pytest-cov=2.*
   - pre-commit=2.*{% if cookiecutter.code_formatter == 'black' %}

--- a/{{cookiecutter.project_slug}}/environment.yml
+++ b/{{cookiecutter.project_slug}}/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7.*{% if cookiecutter.config_file == 'hocon' %}
+  - python=3.9.* {% if cookiecutter.config_file == 'hocon' %}
   - pyhocon=0.3.*{% elif cookiecutter.config_file == 'yaml' %}
   - PyYAML=5.*{% endif %}{% if cookiecutter.create_cli == 'yes' %}
   - pip

--- a/{{cookiecutter.project_slug}}/environment.yml
+++ b/{{cookiecutter.project_slug}}/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.9.* {% if cookiecutter.config_file == 'hocon' %}
+  - python=3.9.*{% if cookiecutter.config_file == 'hocon' %}
   - pyhocon=0.3.*{% elif cookiecutter.config_file == 'yaml' %}
   - PyYAML=5.*{% endif %}{% if cookiecutter.create_cli == 'yes' %}
   - pip


### PR DESCRIPTION
Hey @klamann -- as discussed, here is the brief patch to use python version 3.9.x when using conda as package manager. Cheers, David. 