### PR TITLE
Remove defaults channel due to ToS

### DIFF
--- a/{{cookiecutter.project_slug}}/environment-dev.yml
+++ b/{{cookiecutter.project_slug}}/environment-dev.yml
@@ -3,7 +3,7 @@
 # The regular project dependencies are defined in environment.yml
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
   - python=3.9.*
   - pytest=6.*


### PR DESCRIPTION
My current knowledge is that using Anaconda defaults channel for commercial applications is not compliant with their ToS: https://www.anaconda.com/blog/anaconda-commercial-edition-faq