### PR TITLE
Added autoreload extension into example notebook

### DIFF
--- a/{{cookiecutter.project_slug}}/notebooks/example.ipynb
+++ b/{{cookiecutter.project_slug}}/notebooks/example.ipynb
@@ -12,6 +12,13 @@
    ]
   },
   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": ["%load_ext autoreload\n%autoreload 2"]
+   },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
The first cell in each notebook should include the extension `autoreload`, see [here](https://ipython.org/ipython-doc/3/config/extensions/autoreload.html)
Therefore the JSON file for defining the example notebook was updated.
