### PR TITLE
reset to default workdir

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile__poetry
+++ b/{{cookiecutter.project_slug}}/Dockerfile__poetry
@@ -1,13 +1,17 @@
 ARG PYTHON_VERSION=3.11
 FROM python:${PYTHON_VERSION}-bullseye
+
 LABEL maintainer="{{ cookiecutter.company_name if cookiecutter.company_name else cookiecutter.full_name }}"
 
 RUN pip install poetry && poetry config virtualenvs.create false
-WORKDIR /app
+
+WORKDIR /install
 COPY pyproject.toml poetry.lock ./
 RUN poetry install --only main --no-root --no-interaction && \
     poetry cache clear pypi --all
-COPY ./src /app/src
+COPY ./src ./src
 RUN poetry install --only-root
+
+WORKDIR /
 
 ENTRYPOINT ["python", "-OO", "-m", "{{ cookiecutter.module_name }}"]


### PR DESCRIPTION
just to really see it in code:

clearly enforces best practice of not running from the plain source code
-> source code has to use the module's structure to load code&resources and may not use relative file system paths

this should work for docker builds:
- resources can be loaded as e.g. bytestreams from a module
- env specific config files are populated from container env vars
- etc

