### PR TITLE
Use mambaforge as conda base image

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile__conda
+++ b/{{cookiecutter.project_slug}}/Dockerfile__conda
@@ -5,7 +5,7 @@ FROM condaforge/mambaforge:${IMAGE_TAG}
 LABEL maintainer="{{ cookiecutter.company_name if cookiecutter.company_name else cookiecutter.full_name }}"
 
 WORKDIR /{{cookiecutter.module_name}}
-COPY . .
+COPY environment.yml .
 
 RUN conda config --set channel_priority strict && \
     mamba env create -n {{cookiecutter.module_name}}_env -f environment.yml
@@ -13,6 +13,7 @@ RUN conda config --set channel_priority strict && \
 # Make RUN commands use the new environment (see: https://pythonspeed.com/articles/activate-conda-dockerfile/)
 SHELL ["mamba", "run", "-n", "{{cookiecutter.module_name}}_env", "/bin/bash", "-c"]
 
+COPY . .
 RUN python setup.py install
 
 # ENTRYPOINT doesn't use the same shell as RUN so you need the conda stuff

--- a/{{cookiecutter.project_slug}}/Dockerfile__conda
+++ b/{{cookiecutter.project_slug}}/Dockerfile__conda
@@ -1,21 +1,19 @@
-ARG PYTHON_IMAGE_TAG=4.8.2
+ARG IMAGE_TAG=22.9.0-2
 
-FROM continuumio/miniconda3:${PYTHON_IMAGE_TAG}
-{%- if cookiecutter.company_name %}
-LABEL maintainer="{{ cookiecutter.company_name }}"
-{% else %}
-LABEL maintainer="{{ cookiecutter.full_name }}"
-{% endif -%}
+FROM condaforge/mambaforge:${IMAGE_TAG}
+
+LABEL maintainer="{{ cookiecutter.company_name if cookiecutter.company_name else cookiecutter.full_name }}"
+
 WORKDIR /{{cookiecutter.module_name}}
 COPY . .
 
 RUN conda config --set channel_priority strict && \
-    conda env create -n {{cookiecutter.module_name}}_env -f environment.yml
+    mamba env create -n {{cookiecutter.module_name}}_env -f environment.yml
 
 # Make RUN commands use the new environment (see: https://pythonspeed.com/articles/activate-conda-dockerfile/)
-SHELL ["conda", "run", "-n", "{{cookiecutter.module_name}}_env", "/bin/bash", "-c"]
+SHELL ["mamba", "run", "-n", "{{cookiecutter.module_name}}_env", "/bin/bash", "-c"]
 
 RUN python setup.py install
 
 # ENTRYPOINT doesn't use the same shell as RUN so you need the conda stuff
-ENTRYPOINT ["conda", "run", "-n", "{{cookiecutter.module_name}}_env", "python", "-OO", "-m", "{{ cookiecutter.module_name }}"]
+ENTRYPOINT ["mamba", "run", "-n", "{{cookiecutter.module_name}}_env", "python", "-OO", "-m", "{{ cookiecutter.module_name }}"]


### PR DESCRIPTION
#74 

Uses the mambaforge base image for faster dependency resolving.