### PR TITLE
Change metadata version reference to project_slug

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/version.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/version.py
@@ -3,5 +3,5 @@
 except ModuleNotFoundError:
     import importlib_metadata
 
-__version__ = importlib_metadata.version("{{ cookiecutter.module_name }}")
+__version__ = importlib_metadata.version("{{ cookiecutter.project_slug }}")
 {%- else %}__version__ = '0.1.0'{% endif %}


### PR DESCRIPTION
When selecting the environment management option "poetry", the src/version.py fetches the version from the module metadata, rather than fixing it to (initially) "0.1.0". This must reference the name that is created in pyproject.toml, as this is the name that is referred to in the project metadata after install (in site-packages).
![grafik](https://user-images.githubusercontent.com/16917647/214546693-e9edf18a-e7a0-4465-a36f-b2368daabbf6.png)
![grafik](https://user-images.githubusercontent.com/16917647/214546803-f87c89d4-686f-4986-a959-c415b27f93b8.png)

This however is the project_slug, not the module_name.

This PR simply changes that reference in version.py.

The error ocurrs as soon as the module is imported in a notebook or any other outside script, as the version fetch will fail.
![grafik](https://user-images.githubusercontent.com/16917647/214547175-f5194a8e-c786-4637-9334-cd32a6756374.png)
