### PR TITLE
using bdist_wheel so the ci step does not fail anymore

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -49,7 +49,7 @@ build-wheel:
       - dist/{{ cookiecutter.module_name }}-*.whl
     expire_in: 6 mos
   script:
-    - python setup.py dist{%- endif %}
+    - python setup.py bdist_wheel{%- endif %}
 
 {% if cookiecutter.package_manager == 'poetry' -%}
 test-unit:


### PR DESCRIPTION
The build step of the ci pipeline is failing. 