### PR TITLE
Fix/106 readme conda install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Placeholder for future updates and new features.
+## [1.3.1] - 2026-05-04
+
+### Fixed
+- Added missing `pip install -e .` step to the conda Getting Started instructions in the generated README (closes #106). Without this step, module imports fail when running `pytest` or launching notebooks.
 
 ## [1.3.0] - 2026-01-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "at-python-template"
-version = "1.3.0"
+version = "1.3.1"
 description = "This is the official Python Project Template of Alexander Thamm GmbH (AT)"
 authors = [
     "Christian Baur <christian.baur@alexanderthamm.com>",

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -21,6 +21,10 @@ Then activate the environment with:
 
     conda activate {{ cookiecutter.project_slug }}
 
+Next, install the module in editable mode so that imports work correctly in tests and notebooks:
+
+    pip install -e .
+
 To update this environment with your production dependencies, please run:
 
     conda env update --file=environment.yml
@@ -43,7 +47,7 @@ Whenever you run `poetry run <command>`, that `<command>` is actually run inside
 {% elif cookiecutter.package_manager == 'uv' %}
 ## Using `uv` for Project Setup
 
-> 🧰 **Note:** You do **not** need to have Python pre-installed.  
+> 🧰 **Note:** You do **not** need to have Python pre-installed.
 > `uv` includes its own Python runtime and manages everything automatically.
 
 ### 🔧 Installing `uv`


### PR DESCRIPTION
- Added missing `pip install -e .` step to the conda Getting Started instructions in the generated README (closes #106). Without this step, module imports fail when running `pytest` or launching notebooks.