### PR TITLE
feat: add env var substitution example to HOCON config templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-05-04
+
 ### Added
-- Placeholder for future updates and new features.
+- HOCON config templates now demonstrate environment variable substitution (closes #95): `dev.conf` and `prod.conf` include `username: ${USERNAME}`, and `docker-compose.yml` passes `ENV` and `USERNAME` environment variables to the container when `config_file=hocon` is selected.
 
 ## [1.3.0] - 2026-01-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "at-python-template"
-version = "1.3.0"
+version = "1.3.1"
 description = "This is the official Python Project Template of Alexander Thamm GmbH (AT)"
 authors = [
     "Christian Baur <christian.baur@alexanderthamm.com>",

--- a/{{cookiecutter.project_slug}}/config/dev.conf
+++ b/{{cookiecutter.project_slug}}/config/dev.conf
@@ -1,2 +1,3 @@
 environment = "dev"
 logging.level = DEBUG # overrides the log level that is specified in res/default.conf
+username: ${USERNAME}

--- a/{{cookiecutter.project_slug}}/config/prod.conf
+++ b/{{cookiecutter.project_slug}}/config/prod.conf
@@ -1,1 +1,2 @@
 environment = "prod"
+username: ${USERNAME}

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -15,5 +15,10 @@ services:
         {% else %}
         PYTHON_IMAGE_TAG: "3.9-slim"
         {% endif %}
+    {% if cookiecutter.config_file == 'hocon' %}
+    environment:
+      ENV: dev
+      USERNAME: ${USERNAME:-dear user of the at-python-template}
+    {% endif %}
     command: '{% if cookiecutter.create_cli == "yes" %}--help{% else %}--config /app/config/config.yml{% endif %}'
     tty: true


### PR DESCRIPTION
HOCON config templates now demonstrate environment variable substitution (closes #95): `dev.conf` and `prod.conf` include `username: ${USERNAME}`, and `docker-compose.yml` passes `ENV` and `USERNAME` environment variables to the container when `config_file=hocon` is selected.