### PR TITLE
Fix/74 dockerfile micromamba

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Placeholder for future updates and new features.
+## [1.3.1] - 2026-05-04
+
+### Changed
+- Replaced `condaforge/mambaforge` base image with `mambaorg/micromamba:latest` in the conda Dockerfile for faster, smaller builds (closes #74)
+- Removed `SHELL ["mamba", "run", ...]` workaround; environment activation is now handled via `MAMBA_DOCKERFILE_ACTIVATE=1` and `ENV_NAME`, which is the recommended micromamba pattern
+- Improved Docker layer caching by copying `environment.yml` and creating the conda env before copying the full project source
 
 ## [1.3.0] - 2026-01-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "at-python-template"
-version = "1.3.0"
+version = "1.3.1"
 description = "This is the official Python Project Template of Alexander Thamm GmbH (AT)"
 authors = [
     "Christian Baur <christian.baur@alexanderthamm.com>",

--- a/{{cookiecutter.project_slug}}/Dockerfile__conda
+++ b/{{cookiecutter.project_slug}}/Dockerfile__conda
@@ -1,20 +1,19 @@
-ARG IMAGE_TAG=24.7.1-2
-
-FROM condaforge/mambaforge:${IMAGE_TAG}
+FROM mambaorg/micromamba:latest
 
 LABEL maintainer="{{ cookiecutter.company_name if cookiecutter.company_name else cookiecutter.full_name }}"
 
+# Create env from spec before copying the full source for better layer caching
+COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml
+RUN micromamba env create -n {{cookiecutter.module_name}}_env -f /tmp/environment.yml && \
+    micromamba clean --all --yes
+
+# Activate the named env for all subsequent RUN commands and the final CMD/ENTRYPOINT
+# (see https://github.com/mamba-org/micromamba-docker#activating-the-environment)
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+ENV ENV_NAME={{cookiecutter.module_name}}_env
+
 WORKDIR /{{cookiecutter.module_name}}
-COPY environment.yml .
-
-RUN conda config --set channel_priority strict && \
-    mamba env create -n {{cookiecutter.module_name}}_env -f environment.yml
-
-# Make RUN commands use the new environment (see: https://pythonspeed.com/articles/activate-conda-dockerfile/)
-SHELL ["mamba", "run", "-n", "{{cookiecutter.module_name}}_env", "/bin/bash", "-c"]
-
-COPY . .
+COPY --chown=$MAMBA_USER:$MAMBA_USER . .
 RUN python setup.py install
 
-# ENTRYPOINT doesn't use the same shell as RUN so you need the conda stuff
-ENTRYPOINT ["mamba", "run", "-n", "{{cookiecutter.module_name}}_env", "python", "-OO", "-m", "{{ cookiecutter.module_name }}"]
+ENTRYPOINT ["/usr/local/bin/_entrypoint.sh", "python", "-OO", "-m", "{{ cookiecutter.module_name }}"]


### PR DESCRIPTION
- Replaced `condaforge/mambaforge` base image with `mambaorg/micromamba:latest` in the conda Dockerfile for faster, smaller builds (closes #74)
- Removed `SHELL ["mamba", "run", ...]` workaround; environment activation is now handled via `MAMBA_DOCKERFILE_ACTIVATE=1` and `ENV_NAME`, which is the recommended micromamba pattern
- Improved Docker layer caching by copying `environment.yml` and creating the conda env before copying the full project source