### PR TITLE
Feature/39 logging example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.1] - 2026-05-04
 
 ### Changed
-- `main.py` now includes a working logging example (closes #39). When a config file is selected, it calls `util.load_config()` and `util.logging_setup(config)` so logging is initialised from the config on startup. When no config is selected, it falls back to `logging.basicConfig(level=logging.INFO)`. Both variants log an info message so the generated project works end-to-end immediately.
+- Centralised logging setup (closes #39): all config variants now expose a single `util.setup_logging()` function so `main.py` is uniform regardless of the chosen config format. `util__yaml.py` and `util__hocon.py` gain a `setup_logging()` wrapper; a new `util__none.py` provides a standalone `setup_logging()` for the no-config case (renamed to `util.py` by the post-generate hook).
 
 ## [1.3.0] - 2026-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Placeholder for future updates and new features.
+## [1.3.1] - 2026-05-04
+
+### Changed
+- `main.py` now includes a working logging example (closes #39). When a config file is selected, it calls `util.load_config()` and `util.logging_setup(config)` so logging is initialised from the config on startup. When no config is selected, it falls back to `logging.basicConfig(level=logging.INFO)`. Both variants log an info message so the generated project works end-to-end immediately.
 
 ## [1.3.0] - 2026-01-27
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -76,6 +76,10 @@ files_config_hocon = [
     'config/prod.conf',
 ]
 
+files_config_none = [
+    f'{module_dir}/util__none.py',
+]
+
 files_ci_gitlab = {
     ".gitlab-ci.yml",
 }
@@ -141,16 +145,17 @@ def handle_cli():
 def handle_config():
     config_file = '{{ cookiecutter.config_file }}'
     if config_file == 'yaml':
-        _delete_files(files_config_hocon)
+        _delete_files(files_config_hocon + files_config_none)
         shutil.rmtree(f'{module_dir}/res')
         _rename_files(f'src/**/*__yaml.py', '__yaml', '')
     elif config_file == 'hocon':
-        _delete_files(files_config_yaml)
+        _delete_files(files_config_yaml + files_config_none)
         _rename_files(f'src/**/*__hocon.py', '__hocon', '')
     else:
         _delete_files(files_config_hocon + files_config_yaml + ['tests/test_util.py'])
         os.rmdir(f'{module_dir}/res')
         os.rmdir('config')
+        _rename_files(f'src/**/*__none.py', '__none', '')
 
 
 def handle_formatter():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "at-python-template"
-version = "1.3.0"
+version = "1.3.1"
 description = "This is the official Python Project Template of Alexander Thamm GmbH (AT)"
 authors = [
     "Christian Baur <christian.baur@alexanderthamm.com>",

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -99,8 +99,8 @@ def test_config_yaml():
 def test_config_none():
     check_project(
         settings={'config_file': 'none'},
-        files_non_existent=['config', 'src/{module_name}/util.py', 'tests/util.py',
-                            'src/{module_name}/res'])
+        files_existent=['src/{module_name}/util.py'],
+        files_non_existent=['config', 'tests/util.py', 'src/{module_name}/res'])
 
 
 def test_formatter_black_pip():

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/main.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/main.py
@@ -1,6 +1,19 @@
+import logging
+{% if cookiecutter.config_file != 'none' %}
+from {{ cookiecutter.module_name }} import util
+{% endif %}
+logger = logging.getLogger('{{ cookiecutter.module_name }}')
+
+
 def main():
+    {% if cookiecutter.config_file != 'none' -%}
+    config = util.load_config({% if cookiecutter.config_file == 'yaml' %}'config/config.yml'{% else %}None{% endif %})
+    util.logging_setup(config)
+    {% else -%}
+    logging.basicConfig(level=logging.INFO)
+    {% endif -%}
+    logger.info("Looks like you're all set up. Let's get going!")
     # TODO your journey starts here
-    print("hello :)")
 
 
 if __name__ == "__main__":

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/main.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/main.py
@@ -1,17 +1,11 @@
 import logging
-{% if cookiecutter.config_file != 'none' %}
 from {{ cookiecutter.module_name }} import util
-{% endif %}
+
 logger = logging.getLogger('{{ cookiecutter.module_name }}')
 
 
 def main():
-    {% if cookiecutter.config_file != 'none' -%}
-    config = util.load_config({% if cookiecutter.config_file == 'yaml' %}'config/config.yml'{% else %}None{% endif %})
-    util.logging_setup(config)
-    {% else -%}
-    logging.basicConfig(level=logging.INFO)
-    {% endif -%}
+    util.setup_logging()
     logger.info("Looks like you're all set up. Let's get going!")
     # TODO your journey starts here
 

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/util__hocon.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/util__hocon.py
@@ -54,3 +54,8 @@ def logging_setup(config: ConfigTree):
         level = logging.NOTSET
     logging.basicConfig(format=fmt, level=logging.WARNING)
     logger.setLevel(level)
+
+
+def setup_logging(config_path: Union[str, Path] = None):
+    """Load config and configure logging in one call."""
+    logging_setup(load_config(config_path))

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/util__none.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/util__none.py
@@ -1,0 +1,10 @@
+import logging
+
+
+def setup_logging():
+    """Configure basic logging for the application."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s.%(msecs)03d [%(levelname)s]: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/util__yaml.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.module_name}}/util__yaml.py
@@ -48,3 +48,8 @@ def logging_setup(config: Dict):
         level = logging.NOTSET
     logging.basicConfig(format=fmt, level=logging.WARNING)
     logger.setLevel(level)
+
+
+def setup_logging(config_path: Union[str, Path] = 'config/config.yml'):
+    """Load config and configure logging in one call."""
+    logging_setup(load_config(config_path))


### PR DESCRIPTION
Centralised logging setup (closes #39): all config variants now expose a single `util.setup_logging()` function so `main.py` is uniform regardless of the chosen config format. `util__yaml.py` and `util__hocon.py` gain a `setup_logging()` wrapper; a new `util__none.py` provides a standalone `setup_logging()` for the no-config case (renamed to `util.py` by the post-generate hook).